### PR TITLE
Fix bug, staticFiles() could not support not-string file

### DIFF
--- a/jaguar/lib/src/http/mux/muxer.dart
+++ b/jaguar/lib/src/http/mux/muxer.dart
@@ -443,7 +443,7 @@ abstract class Muxable {
           return null;
         }
       }
-      return new Response<Stream<List<int>>>(await file.openRead(),
+      return new StreamResponse(await file.openRead(),
           mimeType: MimeType.ofFile(file));
     },
         pathRegEx: pathRegEx,


### PR DESCRIPTION
Could you publish new version as soon as possible?
Thank you.