### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/dev_proxy/example/client.dart
+++ b/dev_proxy/example/client.dart
@@ -13,7 +13,7 @@ const int kPort = 8085;
 
 Future<Null> printHttpClientResponse(HttpClientResponse resp) async {
   StringBuffer contents = new StringBuffer();
-  await for (String data in resp.transform(utf8.decoder)) {
+  await for (String data in utf8.decoder.bind(resp)) {
     contents.write(data);
   }
 

--- a/jaguar/lib/http/context/context.dart
+++ b/jaguar/lib/http/context/context.dart
@@ -412,7 +412,7 @@ class Context {
 
     // Transform body to [MimeMultipart]
     final transformer = MimeMultipartTransformer(boundary);
-    final Stream<MimeMultipart> stream = bodyStream.transform(transformer);
+    final Stream<MimeMultipart> stream = transformer.bind(bodyStream);
 
     await for (MimeMultipart part in stream) {
       HttpMultipartFormData multipart = HttpMultipartFormData.parse(part);


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
