### PR TITLE
Parallel tests

### DIFF
--- a/jaguar/test/body/body_json_test.dart
+++ b/jaguar/test/body/body_json_test.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../ports.dart' as ports;
 
 class InputModel {
   InputModel(this.input1, this.input2);
@@ -30,9 +31,11 @@ void main() {
   resty.globalClient = http.IOClient();
 
   group('data.body.json', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = Jaguar(port: 10000);
+      print('Using port $port');
+      server = Jaguar(port: port);
       server
         ..post('/one/map', (ctx) async {
           final Map body = await ctx.bodyAsJsonMap();
@@ -67,35 +70,35 @@ void main() {
     test(
         'One.Map',
         () => resty
-            .post('http://localhost:10000/one/map')
+            .post('http://localhost:$port/one/map')
             .json(new InputModel(5, 15))
             .exact(statusCode: 200, body: '20', mimeType: 'text/plain'));
 
     test(
         'One.Convert',
         () => resty
-            .post('http://localhost:10000/one/convert')
+            .post('http://localhost:$port/one/convert')
             .json(new InputModel(30, 5))
             .exact(statusCode: 200, body: '25', mimeType: 'text/plain'));
 
     test(
         'Many.List',
         () => resty
-            .post('http://localhost:10000/many/list')
+            .post('http://localhost:$port/many/list')
             .json([new InputModel(5, 15), new InputModel(50, 55)]).exact(
                 statusCode: 200, body: '(20, 105)', mimeType: 'text/plain'));
 
     test(
         'Many.Convert',
         () => resty
-            .post('http://localhost:10000/many/convert')
+            .post('http://localhost:$port/many/convert')
             .json([new InputModel(30, 5), new InputModel(75, 20)]).exact(
                 statusCode: 200, body: '(25, 55)', mimeType: 'text/plain'));
 
     test(
         'primitive',
         () => resty
-            .put('http://localhost:10000/primitive')
+            .put('http://localhost:$port/primitive')
             .body('4')
             .exact(statusCode: 200, body: '8', mimeType: 'text/plain'));
   });

--- a/jaguar/test/body/cookie_test.dart
+++ b/jaguar/test/body/cookie_test.dart
@@ -6,14 +6,17 @@ import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
 import 'package:client_cookie/client_cookie.dart';
+import '../ports.dart' as ports;
 
 void main() {
   resty.globalClient = http.IOClient();
 
   group('params.cookies', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = Jaguar(port: 10000);
+      print('Using port $port');
+      server = Jaguar(port: port);
       server
         ..get('/cookie/read', (ctx) {
           return ctx.cookies['user']?.value;
@@ -28,7 +31,7 @@ void main() {
     test(
         'read',
         () => resty
-            .get('http://localhost:10000/cookie/read')
+            .get('http://localhost:$port/cookie/read')
             .cookie(ClientCookie('user', 'teja', DateTime.now()))
             .exact(statusCode: 200, mimeType: 'text/plain', body: 'teja'));
   });

--- a/jaguar/test/body/form_data_test.dart
+++ b/jaguar/test/body/form_data_test.dart
@@ -6,14 +6,17 @@ import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
 import 'package:http_parser/http_parser.dart';
+import '../ports.dart' as ports;
 
 void main() {
   resty.globalClient = new http.IOClient();
 
   group('body.form_data', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = Jaguar(port: 10000);
+      print('Using port $port');
+      server = Jaguar(port: port);
       server.post('/form', (ctx) async {
         Map<String, FormField> form = await ctx.bodyAsFormData();
 
@@ -38,7 +41,7 @@ void main() {
     test(
         'read',
         () => resty
-            .post('http://localhost:10000/form')
+            .post('http://localhost:$port/form')
             .multipart({'string': 'Hello '})
             .multipartFile('binary', [1, 2])
             .multipartStringFile('text', "Hello world!",

--- a/jaguar/test/body/path_params_test.dart
+++ b/jaguar/test/body/path_params_test.dart
@@ -5,14 +5,17 @@ import 'package:http/http.dart' as http;
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../ports.dart' as ports;
 
 void main() {
   resty.globalClient = new http.IOClient();
 
   group('params.path', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000);
+      print('Using port $port');
+      server = new Jaguar(port: port);
       server
         ..get('/str/:id', (ctx) => ctx.pathParams['id'])
         ..get('/int/:id', (ctx) => ctx.pathParams.getInt('id', 5) * 10)
@@ -26,31 +29,31 @@ void main() {
 
     test('string', () async {
       await resty
-          .get('http://localhost:10000/str/hello')
+          .get('http://localhost:$port/str/hello')
           .exact(statusCode: 200, mimeType: 'text/plain', body: 'hello');
     });
 
     test('int.nondefault', () async {
       await resty
-          .get('http://localhost:10000/int/2')
+          .get('http://localhost:$port/int/2')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '20');
     });
 
     test('int.default', () async {
       await resty
-          .get('http://localhost:10000/int/boom')
+          .get('http://localhost:$port/int/boom')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '50');
     });
 
     test('double.nondefault', () async {
       await resty
-          .get('http://localhost:10000/double/2.2')
+          .get('http://localhost:$port/double/2.2')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '22.0');
     });
 
     test('double.default', () async {
       await resty
-          .get('http://localhost:10000/double/boom')
+          .get('http://localhost:$port/double/boom')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '55.0');
     });
   });

--- a/jaguar/test/body/query_params_test.dart
+++ b/jaguar/test/body/query_params_test.dart
@@ -5,14 +5,17 @@ import 'package:http/http.dart' as http;
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../ports.dart' as ports;
 
 void main() {
   resty.globalClient = new http.IOClient();
 
   group('params.query', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000);
+      print('Using port $port');
+      server = new Jaguar(port: port);
       server
         ..get('/str', (ctx) => ctx.query['param'])
         ..get('/int', (ctx) => ctx.query.getInt('param', 5) * 10)
@@ -26,34 +29,34 @@ void main() {
 
     test('string', () async {
       await resty
-          .get('http://localhost:10000/str')
+          .get('http://localhost:$port/str')
           .query('param', 'hello')
           .exact(statusCode: 200, mimeType: 'text/plain', body: 'hello');
     });
 
     test('int.nondefault', () async {
       await resty
-          .get('http://localhost:10000/int')
+          .get('http://localhost:$port/int')
           .query('param', '2')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '20');
     });
 
     test('int.default', () async {
       await resty
-          .get('http://localhost:10000/int')
+          .get('http://localhost:$port/int')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '50');
     });
 
     test('double.nondefault', () async {
       await resty
-          .get('http://localhost:10000/double')
+          .get('http://localhost:$port/double')
           .query('param', '2.2')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '22.0');
     });
 
     test('double.default', () async {
       await resty
-          .get('http://localhost:10000/double')
+          .get('http://localhost:$port/double')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '55.0');
     });
   });

--- a/jaguar/test/body/url_encoded_form_test.dart
+++ b/jaguar/test/body/url_encoded_form_test.dart
@@ -5,14 +5,17 @@ import 'package:http/http.dart' as http;
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../ports.dart' as ports;
 
 void main() {
   resty.globalClient = new http.IOClient();
 
   group('body.url_encoded_form', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = Jaguar(port: 10000);
+      print('Using port $port');
+      server = Jaguar(port: port);
       server.post('/form', (ctx) async {
         Map<String, String> form = await ctx.bodyAsUrlEncodedForm();
         return form['a'] + form['b'];
@@ -27,13 +30,13 @@ void main() {
     test(
         'read',
         () => resty
-            .post('http://localhost:10000/form')
+            .post('http://localhost:$port/form')
             .urlEncodedForm({'a': 'Hello ', 'b': 'world!'}).exact(
                 statusCode: 200, mimeType: 'text/plain', body: 'Hello world!'));
     test(
         'correctly decode URI components',
         () => resty
-            .post('http://localhost:10000/form')
+            .post('http://localhost:$port/form')
             .urlEncodedForm({'a': 'It\'s ', 'b': 'Dart and Jaguar(美洲豹)'}).exact(
                 statusCode: 200,
                 mimeType: 'text/plain',

--- a/jaguar/test/interceptor/after/after_test.dart
+++ b/jaguar/test/interceptor/after/after_test.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../../ports.dart' as ports;
 
 void bef(Context ctx) => ctx.addVariable(5);
 
@@ -24,9 +25,11 @@ main() {
   resty.globalClient = new http.IOClient();
 
   group('After', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000);
+      print('Using port $port');
+      server = new Jaguar(port: port);
       server
         ..get('/aft', (_) => null, after: [aft1])
         ..get('/befaft', (_) => null, before: [bef], after: [aft])
@@ -41,19 +44,19 @@ main() {
     test(
         'After',
         () => resty
-            .get('http://localhost:10000/aft')
+            .get('http://localhost:$port/aft')
             .exact(statusCode: 200, mimeType: 'text/plain', body: 'aft1'));
 
     test(
         'Before&After',
         () => resty
-            .get('http://localhost:10000/befaft')
+            .get('http://localhost:$port/befaft')
             .exact(statusCode: 200, mimeType: 'text/plain', body: '25'));
 
     test(
         'ProgramaticAfter',
         () => resty
-            .get('http://localhost:10000/progaft')
+            .get('http://localhost:$port/progaft')
             .exact(statusCode: 200, mimeType: 'text/plain', body: '50'));
   });
 }

--- a/jaguar/test/interceptor/before/before_test.dart
+++ b/jaguar/test/interceptor/before/before_test.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../../ports.dart' as ports;
 
 final Random rand = new Random.secure();
 
@@ -22,9 +23,11 @@ void main() {
   resty.globalClient = new http.IOClient();
 
   group('Custom interceptor:Generated', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = Jaguar(port: 10000);
+      print('Using port $port');
+      server = Jaguar(port: port);
       server
         ..getJson(
             '/two',
@@ -43,7 +46,7 @@ void main() {
     test(
         'one interceptor',
         () => resty
-                .get('http://localhost:10000/two')
+                .get('http://localhost:$port/two')
                 .exact(statusCode: 200, mimeType: 'application/json')
                 .decodeJson<Map>()
                 .then((Map body) {

--- a/jaguar/test/interceptor/exception/exception_test.dart
+++ b/jaguar/test/interceptor/exception/exception_test.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../../ports.dart' as ports;
 
 final Random rand = new Random.secure();
 
@@ -15,9 +16,11 @@ void main() {
   resty.globalClient = new http.IOClient();
 
   group('OnException', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000);
+      print('Using port $port');
+      server = new Jaguar(port: port);
       server
         ..get('/except', (Context ctx) => throw new Exception(),
             onException: [handleException]);
@@ -31,7 +34,7 @@ void main() {
     test(
         'trigger',
         () => resty
-            .get('http://localhost:10000/except')
+            .get('http://localhost:$port/except')
             .exact(statusCode: 200, mimeType: 'text/plain', body: 'exception'));
   });
 }

--- a/jaguar/test/mux/mux_test.dart
+++ b/jaguar/test/mux/mux_test.dart
@@ -5,14 +5,17 @@ import 'package:http/http.dart' as http;
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../ports.dart' as ports;
 
 void main() {
   resty.globalClient = new http.IOClient();
 
   group('mux', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000);
+      print('Using port $port');
+      server = new Jaguar(port: port);
       server
         ..get('/hello', (ctx) {
           ctx.response = Response('Hello world!');
@@ -35,62 +38,62 @@ void main() {
 
     test('GET.SetResponse', () async {
       await resty
-          .get('http://localhost:10000/hello')
+          .get('http://localhost:$port/hello')
           .exact(statusCode: 200, mimeType: 'text/plain', body: 'Hello world!');
     });
 
     test('GET.ReturnValue', () async {
-      await resty.get('http://localhost:10000/returnValue').exact(
+      await resty.get('http://localhost:$port/returnValue').exact(
           statusCode: 200, mimeType: 'text/plain', body: 'Hello world, Champ!');
     });
 
     test('GET.ReturnResponse', () async {
       await resty
-          .get('http://localhost:10000/returnResponse')
+          .get('http://localhost:$port/returnResponse')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '5');
     });
 
     test('Post', () async {
       await resty
-          .post('http://localhost:10000')
+          .post('http://localhost:$port')
           .exact(statusCode: 200, mimeType: 'text/plain', body: 'Post');
     });
 
     test('Put', () async {
       await resty
-          .put('http://localhost:10000')
+          .put('http://localhost:$port')
           .exact(statusCode: 200, mimeType: 'text/plain', body: 'Put');
     });
 
     test('Delete', () async {
       await resty
-          .delete('http://localhost:10000')
+          .delete('http://localhost:$port')
           .exact(statusCode: 200, mimeType: 'text/plain', body: 'Delete');
     });
 
     test('GetJson', () async {
-      await resty.get('http://localhost:10000/json').exact(
+      await resty.get('http://localhost:$port/json').exact(
           statusCode: 200,
           mimeType: 'application/json',
           body: '{"method":"get"}');
     });
 
     test('PostJson', () async {
-      await resty.post('http://localhost:10000/json').exact(
+      await resty.post('http://localhost:$port/json').exact(
           statusCode: 200,
           mimeType: 'application/json',
           body: '{"method":"post"}');
     });
 
     test('PutJson', () async {
-      await resty.put('http://localhost:10000/json').exact(
+      await resty.put('http://localhost:$port/json').exact(
           statusCode: 200,
           mimeType: 'application/json',
           body: '{"method":"put"}');
     });
 
     test('DeleteJson', () async {
-      await resty.delete('http://localhost:10000/json').exact(
+      await resty.delete('http://localhost:$port/json').exact(
           statusCode: 200,
           mimeType: 'application/json',
           body: '{"method":"delete"}');

--- a/jaguar/test/ports.dart
+++ b/jaguar/test/ports.dart
@@ -1,0 +1,8 @@
+library test.jaguar.ports;
+
+import 'dart:math';
+
+const _offset = 10000;
+const _spread = 20000;
+final _rnd = Random();
+int get random => _offset + _rnd.nextInt(_spread);

--- a/jaguar/test/response/empty.dart
+++ b/jaguar/test/response/empty.dart
@@ -5,14 +5,17 @@ import 'package:http/http.dart' as http;
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../ports.dart' as ports;
 
 void main() {
   resty.globalClient = http.IOClient();
 
   group('response', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = Jaguar(port: 10000);
+      print('Using port $port');
+      server = Jaguar(port: port);
       server..get('/empty', (ctx) {});
       await server.serve();
     });
@@ -23,7 +26,7 @@ void main() {
 
     test('empty', () async {
       await resty
-          .get('http://localhost:10000/empty')
+          .get('http://localhost:$port/empty')
           .exact(statusCode: 200, mimeType: 'text/plain', body: '');
     });
   });

--- a/jaguar/test/response/json/json_test.dart
+++ b/jaguar/test/response/json/json_test.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
+import '../../ports.dart' as ports;
 
 class _Info {
   String name;
@@ -23,9 +24,11 @@ void main() {
   resty.globalClient = new http.IOClient();
 
   group('Response.Json', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000);
+      print('Using port $port');
+      server = new Jaguar(port: port);
       server
         ..getJson(
             '/response_processor/podo',
@@ -46,7 +49,7 @@ void main() {
     });
 
     test('ResponseProcessor.Podo', () async {
-      await resty.get('http://localhost:10000/response_processor/podo').exact(
+      await resty.get('http://localhost:$port/response_processor/podo').exact(
           statusCode: 200,
           mimeType: MimeTypes.json,
           body:
@@ -55,12 +58,12 @@ void main() {
 
     test('ResponseProcessor.List', () async {
       await resty
-          .get('http://localhost:10000/response_processor/nums')
+          .get('http://localhost:$port/response_processor/nums')
           .exact(statusCode: 200, mimeType: MimeTypes.json, body: '[1,2,3]');
     });
 
     test('StrResponse.Podo', () async {
-      await resty.get('http://localhost:10000/strresponse/podo').exact(
+      await resty.get('http://localhost:$port/strresponse/podo').exact(
           statusCode: 200,
           mimeType: MimeTypes.json,
           body:
@@ -69,7 +72,7 @@ void main() {
 
     test('StrResponse.List', () async {
       await resty
-          .get('http://localhost:10000/strresponse/nums')
+          .get('http://localhost:$port/strresponse/nums')
           .exact(statusCode: 200, mimeType: MimeTypes.json, body: '[1,2,3]');
     });
   });

--- a/jaguar/test/response/stream/stream_test.dart
+++ b/jaguar/test/response/stream/stream_test.dart
@@ -1,4 +1,4 @@
-library test.response.stream;
+library test.jaguar.response.stream;
 
 import 'package:http/io_client.dart' as http;
 import 'dart:async';
@@ -6,14 +6,17 @@ import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../../ports.dart' as ports;
 
 void main() {
   resty.globalClient = new http.IOClient();
 
   group('route', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000);
+      print('Using port $port');
+      server = new Jaguar(port: port);
       server
         ..get('/stream', (Context ctx) {
           StreamController<List<int>> streamCon =
@@ -36,7 +39,7 @@ void main() {
 
     test(
         'stream',
-        () => resty.get('http://localhost:10000/stream').exact(
+        () => resty.get('http://localhost:$port/stream').exact(
             statusCode: 200,
             bytes: [1, 2, 3, 4, 5, 6, 7, 8],
             mimeType: 'text/plain'));

--- a/jaguar/test/serve/restart_test.dart
+++ b/jaguar/test/serve/restart_test.dart
@@ -5,14 +5,17 @@ import 'package:http/http.dart' as http;
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../ports.dart' as ports;
 
 void main() {
   resty.globalClient = http.IOClient();
 
-  group('mux', () {
+  group('Restart', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000);
+      print('Using port $port');
+      server = new Jaguar(port: port);
       server..get('/hello', (ctx) => 'Hello world!');
       await server.serve();
     });
@@ -23,11 +26,11 @@ void main() {
 
     test('Server.Restart', () async {
       await resty
-          .get('http://localhost:10000/hello')
+          .get('http://localhost:$port/hello')
           .exact(statusCode: 200, mimeType: 'text/plain', body: 'Hello world!');
       await server.restart();
       await resty
-          .get('http://localhost:10000/hello')
+          .get('http://localhost:$port/hello')
           .exact(statusCode: 200, mimeType: 'text/plain', body: 'Hello world!');
     });
   });

--- a/jaguar/test/session/session_test.dart
+++ b/jaguar/test/session/session_test.dart
@@ -1,19 +1,23 @@
+library test.jaguar.session;
+
 import 'package:http/io_client.dart' as http;
 import 'package:http/http.dart' as http;
 import 'package:jaguar/jaguar.dart';
 import 'package:jaguar_resty/jaguar_resty.dart' as resty;
 import 'package:test/test.dart';
 import 'package:collection/collection.dart';
+import '../ports.dart' as ports;
 
 main() {
   resty.globalClient = http.IOClient();
 
   group("Session", () {
     final jar = new resty.CookieJar();
-
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = new Jaguar(port: 10000)
+      print('Using port $port');
+      server = new Jaguar(port: port)
         ..getJson('/api/add/:item', (ctx) async {
           final Session session = await ctx.session;
           final String newItem = ctx.pathParams['item'];
@@ -53,7 +57,7 @@ main() {
 
     test('ParseNUpdate', () async {
       await resty
-          .get('http://localhost:10000/api/add/Dog')
+          .get('http://localhost:$port/api/add/Dog')
           .before(jar)
           .go()
           .json<Map>()
@@ -61,7 +65,7 @@ main() {
         resty.bodyIs({"Action": "Added"}, const MapEquality().equals)
       ]);
       await resty
-          .get('http://localhost:10000/api/add/Cat')
+          .get('http://localhost:$port/api/add/Cat')
           .before(jar)
           .go()
           .json<Map>()
@@ -69,7 +73,7 @@ main() {
         resty.bodyIs({"Action": "Added"}, const MapEquality().equals)
       ]);
       await resty
-          .get('http://localhost:10000/api/add/Mink')
+          .get('http://localhost:$port/api/add/Mink')
           .before(jar)
           .go()
           .json<Map>()
@@ -77,7 +81,7 @@ main() {
         resty.bodyIs({"Action": "Added"}, const MapEquality().equals)
       ]);
       await resty
-          .get('http://localhost:10000/api/remove/Cat')
+          .get('http://localhost:$port/api/remove/Cat')
           .before(jar)
           .go()
           .json<Map>()
@@ -85,7 +89,7 @@ main() {
         resty.bodyIs({"Action": "Removed"}, const MapEquality().equals)
       ]);
       await resty
-          .get('http://localhost:10000/api/remove/Cat')
+          .get('http://localhost:$port/api/remove/Cat')
           .before(jar)
           .go()
           .json<Map>()

--- a/jaguar/test/test_all.dart
+++ b/jaguar/test/test_all.dart
@@ -15,6 +15,7 @@ import 'mux/mux_test.dart' as mux;
 
 import 'response/json/json_test.dart' as responseJson;
 import 'response/stream/stream_test.dart' as responseStream;
+import 'response/empty.dart' as responseEmpty;
 
 import 'serve/restart_test.dart' as serverRestart;
 
@@ -38,6 +39,7 @@ void main() {
 
   responseJson.main();
   responseStream.main();
+  responseEmpty.main();
 
   serverRestart.main();
 

--- a/jaguar/test/websocket/websocket_test.dart
+++ b/jaguar/test/websocket/websocket_test.dart
@@ -4,12 +4,15 @@ import 'dart:io';
 import 'dart:convert';
 import 'package:test/test.dart';
 import 'package:jaguar/jaguar.dart';
+import '../ports.dart' as ports;
 
 void main() {
   group('Websocket', () {
+    final port = ports.random;
     Jaguar server;
     setUpAll(() async {
-      server = Jaguar(port: 10000);
+      print('Using port $port');
+      server = Jaguar(port: port);
       server.wsEcho('/echo');
       server.wsStream('/stream',
           (ctx, ws) => Stream.fromIterable(["1", "2", "3", "4", "5"]));
@@ -23,7 +26,7 @@ void main() {
 
     test('Echo', () async {
       final WebSocket socket =
-          await WebSocket.connect('ws://localhost:10000/echo');
+          await WebSocket.connect('ws://localhost:$port/echo');
       socket.add('5');
       expect(await socket.first, '5');
       await socket.close();
@@ -31,7 +34,7 @@ void main() {
 
     test('Stream', () async {
       final WebSocket socket =
-          await WebSocket.connect('ws://localhost:10000/stream');
+          await WebSocket.connect('ws://localhost:$port/stream');
       final data = await socket.toList();
       expect(data, ["1", "2", "3", "4", "5"]);
       await socket.close();
@@ -39,7 +42,7 @@ void main() {
 
     test('Responder', () async {
       final WebSocket socket =
-          await WebSocket.connect('ws://localhost:10000/responder');
+          await WebSocket.connect('ws://localhost:$port/responder');
       socket.add(json.encode({'id': 1, 'content': 5}));
       expect(json.decode(await socket.first), {'id': 1, 'content': 6});
       await socket.close();


### PR DESCRIPTION
Use different ports (random, between 10000 and 30000) to allow the tests to be run in parallel, as would be the behavior if someone runs `pub run test`.

Also adds the (missing) `response/empty.dart` to `test_all`