### PR TITLE
allow modifying the default response headers

### DIFF
--- a/jaguar/lib/serve/server.dart
+++ b/jaguar/lib/serve/server.dart
@@ -44,6 +44,10 @@ class Jaguar extends Object with Muxable {
 
   final onException = <ExceptionHandler>[];
 
+  static final void Function(HttpHeaders h) _noDefaults = (HttpHeaders h) {};
+
+  final void Function(HttpHeaders h) _defaultResponseHeaders;
+
   /// Logger used to log concise useful information about the request. This is
   /// also available in [Context] so that interceptors and route handlers can also
   /// log.
@@ -65,6 +69,7 @@ class Jaguar extends Object with Muxable {
   /// [errorWriter] is used to write custom error page [Response] in cases of HTTP
   /// errors.
   /// [sessionManager] provides ability to use custom session managers.
+  /// [defaultResponseHeaders] allows modifying the default response headers.
   Jaguar(
       {String address = "0.0.0.0",
       int port = 8080,
@@ -72,7 +77,8 @@ class Jaguar extends Object with Muxable {
       SecurityContext securityContext,
       this.autoCompress = false,
       ErrorWriter errorWriter,
-      SessionManager sessionManager})
+      SessionManager sessionManager,
+      void Function(HttpHeaders headers) defaultResponseHeaders,})
       : errorWriter = errorWriter ?? DefaultErrorWriter(),
         sessionManager = sessionManager ?? JaguarSessionManager(),
         _connectionInfos = [
@@ -81,7 +87,9 @@ class Jaguar extends Object with Muxable {
               port: port,
               securityContext: securityContext,
               multiThread: multiThread)
-        ];
+        ],
+        _defaultResponseHeaders = defaultResponseHeaders ?? _noDefaults
+      ;
 
   /// Start listening for requests also on [connection]
   void alsoTo(ConnectTo connection) {
@@ -110,6 +118,7 @@ class Jaguar extends Object with Muxable {
               shared: ct.multiThread);
         }
         _server[i].autoCompress = autoCompress;
+        _defaultResponseHeaders(_server[i].defaultResponseHeaders);
       }
     } catch (e) {
       for (int i = 0; i < _connectionInfos.length; i++) {

--- a/jaguar/test/headers/modified.dart
+++ b/jaguar/test/headers/modified.dart
@@ -1,0 +1,59 @@
+library test.jaguar.headers.modified;
+
+import 'package:http/io_client.dart' as http;
+import 'package:http/http.dart' as http;
+import 'package:jaguar_resty/expect/expect.dart';
+import 'package:jaguar_resty/jaguar_resty.dart' as resty;
+import 'package:test/test.dart';
+import 'package:jaguar/jaguar.dart';
+
+void main() {
+  resty.globalClient = http.IOClient();
+
+  group('headers modified', () {
+    Jaguar server;
+    setUpAll(() async {
+      server = Jaguar(
+        port: 10000,
+        defaultResponseHeaders: (h) {
+          h.removeAll('x-frame-options');
+          h.add('x-custom', 'value');
+        },
+      );
+      server..get('/empty', (ctx) {});
+      await server.serve();
+    });
+
+    tearDownAll(() async {
+      await server.close();
+    });
+
+    test('added header', () async {
+      await resty
+          .get('http://localhost:10000/empty')
+          .exact(statusCode: 200, headers: {
+        'content-type': 'text/plain; charset=utf-8',
+        'x-xss-protection': '1; mode=block',
+        'x-content-type-options': 'nosniff',
+        'x-custom': 'value',
+        'content-length': '0',
+      });
+    });
+
+    test('removed header', () async {
+      await resty.get('http://localhost:10000/empty').expect([
+        (r) {
+          if (r.headers.containsKey('x-frame-options')) {
+            return <Mismatch>[
+              new MapHasMismatch(
+                'x-frame-options',
+                customMessage: (m) => 'Illegal header ${m.key}!',
+              )
+            ];
+          }
+          return <Mismatch>[];
+        }
+      ]);
+    });
+  });
+}

--- a/jaguar/test/headers/unmodified.dart
+++ b/jaguar/test/headers/unmodified.dart
@@ -1,0 +1,36 @@
+library test.jaguar.headers.unmodified;
+
+import 'package:http/io_client.dart' as http;
+import 'package:http/http.dart' as http;
+import 'package:jaguar_resty/jaguar_resty.dart' as resty;
+import 'package:test/test.dart';
+import 'package:jaguar/jaguar.dart';
+
+void main() {
+  resty.globalClient = http.IOClient();
+
+  group('headers unmodified', () {
+    Jaguar server;
+    setUpAll(() async {
+      server = Jaguar(port: 10000);
+      server..get('/empty', (ctx) {});
+      await server.serve();
+    });
+
+    tearDownAll(() async {
+      await server.close();
+    });
+
+    test('default', () async {
+      await resty
+          .get('http://localhost:10000/empty')
+          .exact(statusCode: 200, headers: {
+        'x-frame-options': 'SAMEORIGIN',
+        'content-type': 'text/plain; charset=utf-8',
+        'x-xss-protection': '1; mode=block',
+        'x-content-type-options': 'nosniff',
+        'content-length': '0',
+      });
+    });
+  });
+}

--- a/jaguar/test/test_all.dart
+++ b/jaguar/test/test_all.dart
@@ -7,6 +7,9 @@ import 'body/path_params_test.dart' as bodyPathParams;
 import 'body/query_params_test.dart' as bodyQueryParams;
 import 'body/url_encoded_form_test.dart' as bodyUrlEncodedForm;
 
+import 'headers/modified.dart' as headersModified;
+import 'headers/unmodified.dart' as headersUnmodified;
+
 import 'interceptor/after/after_test.dart' as interceptAfter;
 import 'interceptor/before/before_test.dart' as interceptBefore;
 import 'interceptor/exception/exception_test.dart' as interceptException;
@@ -29,6 +32,9 @@ void main() {
   bodyPathParams.main();
   bodyQueryParams.main();
   bodyUrlEncodedForm.main();
+
+  headersModified.main();
+  headersUnmodified.main();
 
   interceptAfter.main();
   interceptBefore.main();


### PR DESCRIPTION
By default the underlying http server adds several headers:
```
x-frame-options: SAMEORIGIN
x-xss-protection': 1; mode=block
x-content-type-options: nosniff
```

It is currently impossible to NOT send such an header. 

If I want in my application to allow my page to be visible in an IFRAME, I can only set an illegal value for `X-Frame-Options` in the `after`. I cannot remove it.

Regarding `x-xss-protection`, browsers are [removing support](https://scotthelme.co.uk/security-headers-updates/) for it, in favor of CSP headers.

This feature also allows a more elegant way to centrally add a `Strict-Transport-Security` header, instead of adding it in an `after`.
