### PR TITLE
Added mime type for xhtml

### DIFF
--- a/jaguar/lib/http/common/mimetype.dart
+++ b/jaguar/lib/http/common/mimetype.dart
@@ -6,6 +6,9 @@ abstract class MimeTypes {
   /// Mime type for HTML
   static const String html = "text/html";
 
+  /// Mime type for XHTML
+  static const String xhtml = "application/xhtml+xml";
+
   /// Mime type for Javascript
   static const String javascript = "application/javascript";
 
@@ -71,6 +74,7 @@ abstract class MimeTypes {
   /// Map of file extension to mime type
   static const fromFileExtension = const <String, String>{
     "html": html,
+    "xhtml": xhtml,
     "js": javascript,
     "css": css,
     "dart": dart,

--- a/jaguar/lib/http/mux/muxable.dart
+++ b/jaguar/lib/http/mux/muxable.dart
@@ -439,7 +439,7 @@ abstract class Muxable {
         }
       }
 
-      return StreamResponse(await file.openRead(),
+      return StreamResponse(file.openRead(),
           mimeType: MimeTypes.ofFile(file));
     },
         pathRegEx: pathRegEx,
@@ -473,7 +473,7 @@ abstract class Muxable {
     return this.get(
         path,
         (_) async =>
-            StreamResponse(await f.openRead(), mimeType: MimeTypes.ofFile(f)),
+            StreamResponse(f.openRead(), mimeType: MimeTypes.ofFile(f)),
         pathRegEx: pathRegEx,
         statusCode: statusCode,
         mimeType: mimeType,


### PR DESCRIPTION
When serving static files, `.xhtml` files were treated as plain text.

I added a constant for xhtml to `MimeTypes` class so now `.xhtml` files are automatically served with `application/xhtml+xml` MIME-type